### PR TITLE
use a cleaner interface for prediction and indexing

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -62,7 +62,7 @@ export const initMap = (
     }
   }
 
-  entityManager.commitState()
+  entityManager.commitPrediction()
 
   return terrainLayer
 }

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -209,5 +209,9 @@ export class Server {
         }
         break
     }
+
+    // On the server, there is no reason to accumulate prediction state, because
+    // the server simulation is authoritative.
+    this.entityManager.commitPrediction()
   }
 }

--- a/src/systems/client/syncServerState.ts
+++ b/src/systems/client/syncServerState.ts
@@ -15,7 +15,7 @@ export const update = (c: Client, dt: number, frame: number): void => {
     return
   }
 
-  c.entityManager.restoreCheckpoints()
+  c.entityManager.undoPrediction()
 
   c.serverFrameUpdates.forEach((frameMessage) => {
     simulate(
@@ -31,7 +31,7 @@ export const update = (c: Client, dt: number, frame: number): void => {
     c.committedFrame = frameMessage.frame
   })
 
-  c.entityManager.commitState()
+  c.entityManager.commitPrediction()
 
   c.localMessageHistory = c.localMessageHistory.filter(
     (m) => m.frame > c.committedFrame,


### PR DESCRIPTION
Change:

- `commitState` -> `commitPrediction`
- `restoreCheckpoint` -> `undoPrediction`
- Make a private `index` and `unindex` interface any time you want to store internal references to entities. This includes the main entity mapping, but also indexes like the quadtree and the player number index. `register` and `markForDeletion` become public-facing wrappers that also mark the entities as in an uncommitted/predicted state.