### PR TITLE
Refactor mesh loading to preserve point data in JS memory

### DIFF
--- a/src/renderer/common.ts
+++ b/src/renderer/common.ts
@@ -2,6 +2,14 @@ import { mat4 } from 'gl-matrix'
 
 import { Immutable } from '~/types/immutable'
 
+export type BufferArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Uint32Array
+  | Float32Array
+
 export enum ModelPrimitive {
   Lines,
   Triangles,
@@ -26,33 +34,40 @@ export enum MeshPrimitive {
   Lines,
 }
 
-export interface Buffer {
-  bufferData: ArrayBuffer
-  glBuffer: WebGLBuffer
+export interface Buffer<T> {
+  buffer: T
   glType: GLenum // FLOAT, etc.
   componentCount: number // total number of component values of type glType
   componentsPerAttrib: number // number of component values per attribute
 }
 
-export interface TriangleMesh {
-  positions: Buffer
-  normals: Buffer
-  indices: Buffer
+export interface TriangleMesh<T> {
+  positions: Buffer<T>
+  normals: Buffer<T>
+  indices: Buffer<T>
   primitive: MeshPrimitive.Triangles
 }
 
-export interface LineMesh {
-  positions: Buffer
-  normals: Buffer
-  indices: Buffer
+export interface LineMesh<T> {
+  positions: Buffer<T>
+  normals: Buffer<T>
+  indices: Buffer<T>
   primitive: MeshPrimitive.Lines
 }
 
-export type Mesh = TriangleMesh | LineMesh
+export type DataMesh = TriangleMesh<BufferArray> | LineMesh<BufferArray>
+export type RenderMesh = TriangleMesh<WebGLBuffer> | LineMesh<WebGLBuffer>
 
 export interface ModelNode {
   name: string
-  mesh?: Mesh
+  mesh?: DataMesh
   transform?: mat4
   children: ModelNode[]
+}
+
+export interface RenderNode {
+  name: string
+  mesh?: RenderMesh
+  transform?: mat4
+  children: RenderNode[]
 }

--- a/src/renderer/processors/lineMeshProcessor.ts
+++ b/src/renderer/processors/lineMeshProcessor.ts
@@ -1,0 +1,9 @@
+import { ModelNode, RenderNode } from '~/renderer/common'
+
+export const getGLLineMesh: (
+  m: ModelNode,
+  gl: WebGL2RenderingContext,
+) => RenderNode = (model, gl) => {
+  console.log(model, gl)
+  throw 'Unimplemented'
+}

--- a/src/renderer/processors/passthroughMeshProcessor.ts
+++ b/src/renderer/processors/passthroughMeshProcessor.ts
@@ -1,0 +1,62 @@
+import {
+  Buffer,
+  BufferArray,
+  ModelNode,
+  RenderMesh,
+  RenderNode,
+} from '~/renderer/common'
+
+export const getGLPassthroughMesh: (
+  m: ModelNode,
+  gl: WebGL2RenderingContext,
+) => RenderNode = (model, gl) => {
+  const node: RenderNode = {
+    name: model.name,
+    children: [],
+  }
+
+  if (model.transform != null) {
+    node.transform = model.transform
+  }
+
+  if (model.mesh != null) {
+    const newMesh: RenderMesh = {
+      positions: getGlBuffer(model.mesh.positions, gl),
+      normals: getGlBuffer(model.mesh.normals, gl),
+      indices: getGlBuffer(model.mesh.indices, gl, { isIndexBuffer: true }),
+      primitive: model.mesh.primitive,
+    }
+
+    node.mesh = newMesh
+  }
+
+  for (const child of model.children) {
+    node.children.push(getGLPassthroughMesh(child, gl))
+  }
+
+  return node
+}
+
+const getGlBuffer: (
+  buffer: Buffer<BufferArray>,
+  gl: WebGL2RenderingContext,
+  opts?: { isIndexBuffer: boolean },
+) => Buffer<WebGLBuffer> = (buffer, gl, opts = { isIndexBuffer: false }) => {
+  // Write data to a GL buffer
+  const glBuffer = gl.createBuffer()
+  if (glBuffer === null) {
+    throw new Error('unable to create GL buffer')
+  }
+  // Specifying the precise target matters because it sets a property on the
+  // buffer object.
+  const target = opts.isIndexBuffer ? gl.ELEMENT_ARRAY_BUFFER : gl.ARRAY_BUFFER
+  gl.bindVertexArray(null)
+  gl.bindBuffer(target, glBuffer)
+  gl.bufferData(target, buffer.buffer, gl.STATIC_DRAW)
+  return {
+    buffer: glBuffer,
+    glType: buffer.glType,
+    componentCount: buffer.componentCount,
+    componentsPerAttrib: buffer.componentsPerAttrib,
+  }
+}


### PR DESCRIPTION
- Adds concepts of "processors" to renderer
  - "passthrough" processor will support all existing GLTF types
  - "lineMesh" processor is unimplemented for future work