### PR TITLE
use different aabb structure

### DIFF
--- a/src/client/ClientSim.ts
+++ b/src/client/ClientSim.ts
@@ -27,6 +27,7 @@ import * as systems from '~/systems'
 import { CursorMode } from '~/systems/client/playerInput'
 import * as terrain from '~/terrain'
 import { Immutable } from '~/types/immutable'
+import * as aabb2 from '~/util/aabb2'
 import { discardUntil } from '~/util/array'
 import * as math from '~/util/math'
 import { RunningAverage } from '~/util/RunningAverage'
@@ -91,10 +92,7 @@ export class ClientSim {
     this.modelLoader = config.modelLoader
     this.debugDraw = config.debugDraw
 
-    this.entityManager = new EntityManager([
-      [0, 0],
-      [0, 0],
-    ])
+    this.entityManager = new EntityManager(aabb2.create())
     this.localMessageHistory = []
     this.playerInputState = { cursorMode: CursorMode.NONE }
     this.serverConnection = null
@@ -152,14 +150,13 @@ export class ClientSim {
     // Level setup
     this.map = Map.fromRaw(gameProgression[this.currentLevel])
     const worldOrigin = vec2.scale(vec2.create(), this.map.origin, TILE_SIZE)
+    const dimensions = vec2.scale(vec2.create(), this.map.dimensions, TILE_SIZE)
 
     this.entityManager = new EntityManager([
-      worldOrigin,
-      vec2.add(
-        vec2.create(),
-        worldOrigin,
-        vec2.scale(vec2.create(), this.map.dimensions, TILE_SIZE),
-      ),
+      worldOrigin[0],
+      worldOrigin[1],
+      worldOrigin[0] + dimensions[0],
+      worldOrigin[1] + dimensions[1],
     ])
     this.entityManager.currentPlayer = this.playerNumber!
 

--- a/src/components/Damageable.ts
+++ b/src/components/Damageable.ts
@@ -1,8 +1,7 @@
-import { vec2 } from 'gl-matrix'
-
 import * as hitbox from '~/components/Hitbox'
 import { Transform } from '~/components/Transform'
 import { Immutable } from '~/types/immutable'
+import { Aabb2 } from '~/util/aabb2'
 
 export type Damageable = {
   maxHealth: number
@@ -21,7 +20,7 @@ export function make(health: number, hitbox: hitbox.Hitbox): Damageable {
 export function aabb(
   d: Immutable<Damageable>,
   transform: Immutable<Transform>,
-): [vec2, vec2] {
+): Aabb2 {
   return hitbox.aabb(d.hitbox, transform.position)
 }
 

--- a/src/components/Damager.ts
+++ b/src/components/Damager.ts
@@ -1,10 +1,9 @@
-import { vec2 } from 'gl-matrix'
-
 import { Hitbox } from '~/components/Hitbox'
 import * as hitbox from '~/components/Hitbox'
 import { Transform } from '~/components/Transform'
 import { EntityId } from '~/entities/EntityId'
 import { Immutable } from '~/types/immutable'
+import { Aabb2 } from '~/util/aabb2'
 
 export type Damager = {
   damageValue: number
@@ -15,7 +14,7 @@ export type Damager = {
 export function aabb(
   d: Immutable<Damager>,
   transform: Immutable<Transform>,
-): [vec2, vec2] {
+): Aabb2 {
   return hitbox.aabb(d.hitbox, transform.position)
 }
 

--- a/src/components/Hitbox.ts
+++ b/src/components/Hitbox.ts
@@ -9,15 +9,9 @@ export type Hitbox = {
 }
 
 export function aabb(h: Immutable<Hitbox>, position: Immutable<vec2>): Aabb2 {
-  const offsetPosition = vec2.add(vec2.create(), h.offset, position)
-
-  return [
-    offsetPosition,
-    vec2.fromValues(
-      offsetPosition[0] + h.dimensions[0],
-      offsetPosition[1] + h.dimensions[1],
-    ),
-  ]
+  const x1 = h.offset[0] + position[0]
+  const y1 = h.offset[1] + position[1]
+  return [x1, y1, x1 + h.dimensions[0], y1 + h.dimensions[1]]
 }
 
 export function clone(h: Immutable<Hitbox>): Hitbox {

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -1,5 +1,3 @@
-import { vec2 } from 'gl-matrix'
-
 import * as bullet from '~/components/Bullet'
 import { Bullet } from '~/components/Bullet'
 import * as damageable from '~/components/Damageable'
@@ -21,6 +19,7 @@ import { PickupType } from '~/systems/pickups'
 import { ShooterComponent, clone as shooterClone } from '~/systems/shooter'
 import { TurretComponent } from '~/systems/turret'
 import * as turret from '~/systems/turret'
+import { Aabb2 } from '~/util/aabb2'
 import { Quadtree } from '~/util/quadtree'
 import { minBiasAabbOverlap } from '~/util/quadtree/helpers'
 import { SortedSet } from '~/util/SortedSet'
@@ -28,7 +27,7 @@ import { tileBox } from '~/util/tileMath'
 
 type QuadtreeEntity = {
   id: EntityId
-  aabb: [vec2, vec2]
+  aabb: Aabb2
 }
 
 export class EntityManager {
@@ -66,7 +65,7 @@ export class EntityManager {
   friendlyTeam: SortedSet<EntityId>
   private quadtree: Quadtree<EntityId, QuadtreeEntity>
 
-  constructor(playfieldAabb: [vec2, vec2]) {
+  constructor(playfieldAabb: Aabb2) {
     this.nextEntityIdUncommitted = 0
     this.nextEntityIdCommitted = 0
     this.currentPlayer = -1
@@ -122,7 +121,7 @@ export class EntityManager {
     this.quadtree = new Quadtree<EntityId, QuadtreeEntity>({
       maxItems: 4,
       aabb: playfieldAabb,
-      comparator: (aabb: [vec2, vec2], e: QuadtreeEntity) => {
+      comparator: (aabb: Aabb2, e: QuadtreeEntity) => {
         return minBiasAabbOverlap(aabb, e.aabb)
       },
     })
@@ -289,7 +288,7 @@ export class EntityManager {
     this.quadtree.remove(id)
   }
 
-  public queryByWorldPos(aabb: [vec2, vec2]): EntityId[] {
+  public queryByWorldPos(aabb: Aabb2): EntityId[] {
     // Start with known non-moving entities
     const results = new Set<EntityId>(
       this.quadtree.query(aabb).map((r) => r.id),

--- a/src/server/ServerSim.ts
+++ b/src/server/ServerSim.ts
@@ -10,6 +10,7 @@ import { ClientMessage, ClientMessageType } from '~/network/ClientMessage'
 import { ServerMessageType } from '~/network/ServerMessage'
 import { SimulationPhase, simulate } from '~/simulate'
 import * as terrain from '~/terrain'
+import * as aabb2 from '~/util/aabb2'
 import { RunningAverage } from '~/util/RunningAverage'
 import * as time from '~/util/time'
 
@@ -43,10 +44,7 @@ export class ServerSim {
 
   constructor(config: { playerCount: number; minFramesBehindClient: number }) {
     this.clientMessagesByFrame = []
-    this.entityManager = new EntityManager([
-      [0, 0],
-      [0, 0],
-    ])
+    this.entityManager = new EntityManager(aabb2.create())
     this.clients = []
     this.playerCount = config.playerCount
     this.simulationFrame = 0
@@ -154,14 +152,17 @@ export class ServerSim {
             this.map.origin,
             TILE_SIZE,
           )
+          const dimensions = vec2.scale(
+            vec2.create(),
+            this.map.dimensions,
+            TILE_SIZE,
+          )
 
           this.entityManager = new EntityManager([
-            worldOrigin,
-            vec2.add(
-              vec2.create(),
-              worldOrigin,
-              vec2.scale(vec2.create(), this.map.dimensions, TILE_SIZE),
-            ),
+            worldOrigin[0],
+            worldOrigin[1],
+            worldOrigin[0] + dimensions[0],
+            worldOrigin[1] + dimensions[1],
           ])
           this.terrainLayer = initMap(this.entityManager, this.map)
 

--- a/src/systems/attack.ts
+++ b/src/systems/attack.ts
@@ -10,7 +10,7 @@ import { DebugDrawObject } from '~/DebugDraw'
 import { ParticleEmitter } from '~/particles/ParticleEmitter'
 import { UnlitObjectType } from '~/renderer/Renderer3d'
 import { SimState, simulationPhaseDebugColor } from '~/simulate'
-import * as aabb from '~/util/aabb2'
+import * as aabb2 from '~/util/aabb2'
 import { radialTranslate2 } from '~/util/math'
 
 export const update = (simState: SimState): void => {
@@ -19,7 +19,7 @@ export const update = (simState: SimState): void => {
 
     for (const [entityId, d] of simState.entityManager.damageables) {
       const xform = simState.entityManager.transforms.get(entityId)!
-      const [center, size] = aabb.centerSize(damageableAabb(d, xform))
+      const [center, size] = aabb2.centerSize(damageableAabb(d, xform))
       objects.push({
         object: {
           type: UnlitObjectType.Model,
@@ -43,7 +43,7 @@ export const update = (simState: SimState): void => {
     const attackerAabb = damagerAabb(damager, transform)
 
     simState.debugDraw.draw3d(() => {
-      const [center, size] = aabb.centerSize(attackerAabb)
+      const [center, size] = aabb2.centerSize(attackerAabb)
       return [
         {
           object: {
@@ -77,7 +77,7 @@ export const update = (simState: SimState): void => {
         damageableId,
       )!
 
-      return aabb.overlap(
+      return aabb2.overlap(
         damageableAabb(damageable, targetTransform),
         attackerAabb,
       )

--- a/src/systems/turret.ts
+++ b/src/systems/turret.ts
@@ -11,6 +11,7 @@ import { EntityId } from '~/entities/EntityId'
 import { ParticleEmitter } from '~/particles/ParticleEmitter'
 import { SimState } from '~/simulate'
 import { Immutable } from '~/types/immutable'
+import { Aabb2 } from '~/util/aabb2'
 import { segmentToAabb } from '~/util/collision'
 import { getAngle, radialTranslate2, rotateUntil } from '~/util/math'
 import { SortedSet } from '~/util/SortedSet'
@@ -43,10 +44,13 @@ export const update = (
   const turretIds = new SortedSet<EntityId>()
   for (const id of entityManager.friendlyTeam) {
     const position = entityManager.transforms.get(id)!.position
-    const searchSpace: [vec2, vec2] = [
-      vec2.sub(vec2.create(), position, vec2.fromValues(RANGE, RANGE)),
-      vec2.add(vec2.create(), position, vec2.fromValues(RANGE, RANGE)),
+    const searchSpace: Aabb2 = [
+      position[0] - RANGE,
+      position[1] - RANGE,
+      position[0] + RANGE,
+      position[1] + RANGE,
     ]
+
     for (const turretId of entityManager.queryByWorldPos(searchSpace)) {
       if (entityManager.turrets.has(turretId)) {
         turretIds.add(turretId)
@@ -62,11 +66,11 @@ export const update = (
     // I. Find a target
 
     const shootables: { id: EntityId; transform: Immutable<Transform> }[] = []
-    const turretOrigin = transform.position
-
-    const searchSpace: [vec2, vec2] = [
-      vec2.sub(vec2.create(), turretOrigin, vec2.fromValues(RANGE, RANGE)),
-      vec2.add(vec2.create(), turretOrigin, vec2.fromValues(RANGE, RANGE)),
+    const searchSpace: Aabb2 = [
+      transform.position[0] - RANGE,
+      transform.position[1] - RANGE,
+      transform.position[0] + RANGE,
+      transform.position[1] + RANGE,
     ]
 
     for (const targetId of entityManager.queryByWorldPos(searchSpace)) {

--- a/src/systems/wallCollider.ts
+++ b/src/systems/wallCollider.ts
@@ -5,6 +5,7 @@ import { TILE_SIZE } from '~/constants'
 import { SimState } from '~/simulate'
 import { Immutable } from '~/types/immutable'
 import * as aabb2 from '~/util/aabb2'
+import { Aabb2 } from '~/util/aabb2'
 import { tileBox, tileCoords } from '~/util/tileMath'
 
 enum DirectionCollision {
@@ -18,9 +19,11 @@ export const update = (simState: Pick<SimState, 'entityManager'>): void => {
   for (const [id] of simState.entityManager.playerNumbers) {
     const transform = simState.entityManager.transforms.get(id)!
     const position = transform.position
-    const checkAabb: [vec2, vec2] = [
-      vec2.fromValues(position[0] - TILE_SIZE, position[1] - TILE_SIZE),
-      vec2.fromValues(position[0] + TILE_SIZE, position[1] + TILE_SIZE),
+    const checkAabb: Aabb2 = [
+      position[0] - TILE_SIZE,
+      position[1] - TILE_SIZE,
+      position[0] + TILE_SIZE,
+      position[1] + TILE_SIZE,
     ]
     const queried = simState.entityManager.queryByWorldPos(checkAabb)
     const playerBox = tileBox(position)
@@ -44,46 +47,46 @@ export const update = (simState: Pick<SimState, 'entityManager'>): void => {
       if (aabb2.overlap(playerBox, wallBox)) {
         // North
         if (
-          previousPlayerBox[1][1] <= wallBox[0][1] &&
-          playerBox[1][1] > wallBox[0][1]
+          previousPlayerBox[aabb2.Elem.y2] <= wallBox[aabb2.Elem.y1] &&
+          playerBox[aabb2.Elem.y2] > wallBox[aabb2.Elem.y1]
         ) {
           collisions.push({
             transform: otherTransform,
             direction: DirectionCollision.North,
-            value: wallBox[0][1],
+            value: wallBox[aabb2.Elem.y1],
           })
         }
         // South
         if (
-          previousPlayerBox[0][1] >= wallBox[1][1] &&
-          playerBox[0][1] < wallBox[1][1]
+          previousPlayerBox[aabb2.Elem.y1] >= wallBox[aabb2.Elem.y2] &&
+          playerBox[aabb2.Elem.y1] < wallBox[aabb2.Elem.y2]
         ) {
           collisions.push({
             transform: otherTransform,
             direction: DirectionCollision.South,
-            value: wallBox[1][1],
+            value: wallBox[aabb2.Elem.y2],
           })
         }
         // East
         if (
-          previousPlayerBox[0][0] >= wallBox[1][0] &&
-          playerBox[0][0] < wallBox[1][0]
+          previousPlayerBox[aabb2.Elem.x1] >= wallBox[aabb2.Elem.x2] &&
+          playerBox[aabb2.Elem.x1] < wallBox[aabb2.Elem.x2]
         ) {
           collisions.push({
             transform: otherTransform,
             direction: DirectionCollision.East,
-            value: wallBox[1][0],
+            value: wallBox[aabb2.Elem.x2],
           })
         }
         // West
         if (
-          previousPlayerBox[1][0] <= wallBox[0][0] &&
-          playerBox[1][0] > wallBox[0][0]
+          previousPlayerBox[aabb2.Elem.x2] <= wallBox[aabb2.Elem.x1] &&
+          playerBox[aabb2.Elem.x2] > wallBox[aabb2.Elem.x1]
         ) {
           collisions.push({
             transform: otherTransform,
             direction: DirectionCollision.West,
-            value: wallBox[0][0],
+            value: wallBox[aabb2.Elem.x1],
           })
         }
       }

--- a/src/util/__test__/aabb2.test.ts
+++ b/src/util/__test__/aabb2.test.ts
@@ -1,0 +1,57 @@
+import * as aabb2 from '../aabb2'
+import { Aabb2 } from '../aabb2'
+
+test('size', () => {
+  expect(aabb2.size([1, 2, 3, 4])).toStrictEqual([2, 2])
+})
+
+test('centerSize', () => {
+  expect(aabb2.centerSize([1, 2, 3, 4])).toStrictEqual([
+    [2, 3],
+    [2, 2],
+  ])
+})
+
+test('overlap', () => {
+  const cases: [Aabb2, Aabb2, boolean][] = [
+    [[1, 2, 3, 4], [1, 2, 3, 4], true], // same AABB
+    [[1, 2, 3, 4], [2, 3, 5, 6], true], // SE/NW corner overlap
+    [[1, 2, 3, 4], [2, 1, 4, 3], true], // NE/SW corner overlap
+    [[1, 2, 3, 4], [3, 4, 5, 6], true], // SE/NW corner touch
+    [[1, 2, 3, 4], [3, 1, 4, 2], true], // NE/SW corner touch
+    [[1, 2, 3, 4], [0, 1, 4, 5], true], // full enclosure
+    [[1, 2, 3, 4], [0, 3, 4, 5], true], // enclosing north/south
+    [[1, 2, 3, 4], [2, 1, 4, 5], true], // enclosing east/west
+    [[1, 2, 3, 4], [1, 5, 3, 7], false], // disjoint north/south
+    [[1, 2, 3, 4], [5, 2, 7, 4], false], // disjoint east/west
+    [[1, 2, 3, 4], [4, 5, 6, 7], false], // disjoint se/nw
+    [[1, 2, 3, 4], [4, -1, 6, 1], false], // disjoint ne/sw
+  ]
+
+  for (const [a, b, want] of cases) {
+    expect(aabb2.overlap(a, b)).toBe(want)
+    expect(aabb2.overlap(b, a)).toBe(want)
+  }
+})
+
+test('overlapArea', () => {
+  const cases: [Aabb2, Aabb2, number][] = [
+    [[1, 2, 3, 4], [1, 2, 3, 4], 4], // same AABB
+    [[1, 2, 3, 4], [2, 3, 5, 6], 1], // SE/NW corner overlap
+    [[1, 2, 3, 4], [2, 1, 4, 3], 1], // NE/SW corner overlap
+    [[1, 2, 3, 4], [3, 4, 5, 6], 0], // SE/NW corner touch
+    [[1, 2, 3, 4], [3, 1, 4, 2], 0], // NE/SW corner touch
+    [[1, 2, 3, 4], [0, 1, 4, 5], 4], // full enclosure
+    [[1, 2, 3, 4], [0, 3, 4, 5], 2], // enclosing north/south
+    [[1, 2, 3, 4], [2, 1, 4, 5], 2], // enclosing east/west
+    [[1, 2, 3, 4], [1, 5, 3, 7], 0], // disjoint north/south
+    [[1, 2, 3, 4], [5, 2, 7, 4], 0], // disjoint east/west
+    [[1, 2, 3, 4], [4, 5, 6, 7], 0], // disjoint se/nw
+    [[1, 2, 3, 4], [4, -1, 6, 1], 0], // disjoint ne/sw
+  ]
+
+  for (const [a, b, want] of cases) {
+    expect(aabb2.overlapArea(a, b)).toBe(want)
+    expect(aabb2.overlapArea(b, a)).toBe(want)
+  }
+})

--- a/src/util/aabb2.ts
+++ b/src/util/aabb2.ts
@@ -1,24 +1,39 @@
-import { vec2 } from 'gl-matrix'
-
 import { Immutable } from '~/types/immutable'
 
-export type Aabb2 = [vec2, vec2]
+// x1, y1, x2, y2
+export type Aabb2 = [number, number, number, number]
 
-export function size(aabb: Immutable<Aabb2>): vec2 {
-  return vec2.fromValues(aabb[1][0] - aabb[0][0], aabb[1][0] - aabb[0][0])
+export enum Elem {
+  x1,
+  y1,
+  x2,
+  y2,
 }
 
-export function centerSize(aabb: Immutable<Aabb2>): [vec2, vec2] {
+export function create(): Aabb2 {
+  return [0, 0, 0, 0]
+}
+
+export function size(aabb: Immutable<Aabb2>): [number, number] {
+  return [aabb[Elem.x2] - aabb[Elem.x1], aabb[Elem.y2] - aabb[Elem.y1]]
+}
+
+/**
+ * Decompose an AABB into a center point and a size (width/height).
+ */
+export function centerSize(
+  aabb: Immutable<Aabb2>,
+): [[number, number], [number, number]] {
   const s = size(aabb)
-  return [vec2.fromValues(aabb[0][0] + s[0] / 2, aabb[0][1] + s[1] / 2), s]
+  return [[aabb[Elem.x1] + s[0] / 2, aabb[Elem.y1] + s[1] / 2], s]
 }
 
 export const overlap = (a: Immutable<Aabb2>, b: Immutable<Aabb2>): boolean => {
   return (
-    a[0][0] <= b[1][0] &&
-    a[1][0] >= b[0][0] &&
-    a[0][1] <= b[1][1] &&
-    a[1][1] >= b[0][1]
+    a[Elem.x1] <= b[Elem.x2] &&
+    a[Elem.x2] >= b[Elem.x1] &&
+    a[Elem.y1] <= b[Elem.y2] &&
+    a[Elem.y2] >= b[Elem.y1]
   )
 }
 
@@ -27,7 +42,13 @@ export const overlapArea = (
   b: Immutable<Aabb2>,
 ): number => {
   return (
-    Math.max(0, Math.min(a[1][0], b[1][0]) - Math.max(a[0][0], b[0][0])) *
-    Math.max(0, Math.min(a[1][1], b[1][1]) - Math.max(a[0][1], b[0][1]))
+    Math.max(
+      0,
+      Math.min(a[Elem.x2], b[Elem.x2]) - Math.max(a[Elem.x1], b[Elem.x1]),
+    ) *
+    Math.max(
+      0,
+      Math.min(a[Elem.y2], b[Elem.y2]) - Math.max(a[Elem.y1], b[Elem.y1]),
+    )
   )
 }

--- a/src/util/collision.ts
+++ b/src/util/collision.ts
@@ -1,18 +1,16 @@
 import { glMatrix, vec2 } from 'gl-matrix'
 
 import { Immutable } from '~/types/immutable'
+import { Aabb2 } from '~/util/aabb2'
 import * as aabb2 from '~/util/aabb2'
 
-const aabbFromSegment = (s: Immutable<[vec2, vec2]>): [vec2, vec2] => {
-  const northwest = vec2.fromValues(
+const aabbFromSegment = (s: Immutable<[vec2, vec2]>): Aabb2 => {
+  return [
     Math.min(s[0][0], s[1][0]),
     Math.min(s[0][1], s[1][1]),
-  )
-  const southeast = vec2.fromValues(
     Math.max(s[0][0], s[1][0]),
     Math.max(s[0][1], s[1][1]),
-  )
-  return [northwest, southeast]
+  ]
 }
 
 const crossScalar = (v: vec2, w: vec2): number => {
@@ -52,12 +50,12 @@ export const segmentSegment = (
 
 export const segmentToAabb = (
   s: Immutable<[vec2, vec2]>,
-  aabb: Immutable<[vec2, vec2]>,
+  aabb: Immutable<Aabb2>,
 ): boolean => {
-  const nw = vec2.fromValues(aabb[0][0], aabb[0][1])
-  const ne = vec2.fromValues(aabb[1][0], aabb[0][1])
-  const sw = vec2.fromValues(aabb[0][0], aabb[1][1])
-  const se = vec2.fromValues(aabb[1][0], aabb[1][1])
+  const nw = vec2.fromValues(aabb[aabb2.Elem.x1], aabb[aabb2.Elem.y1])
+  const ne = vec2.fromValues(aabb[aabb2.Elem.x2], aabb[aabb2.Elem.y1])
+  const sw = vec2.fromValues(aabb[aabb2.Elem.x1], aabb[aabb2.Elem.y2])
+  const se = vec2.fromValues(aabb[aabb2.Elem.x2], aabb[aabb2.Elem.y2])
 
   return (
     segmentSegment(s, [nw, ne]) ||

--- a/src/util/quadtree/Quadtree.ts
+++ b/src/util/quadtree/Quadtree.ts
@@ -1,5 +1,3 @@
-import { vec2 } from 'gl-matrix'
-
 import {
   Comparator,
   QuadtreeItem,
@@ -8,16 +6,18 @@ import {
   nodeQuery,
 } from './helpers'
 
+import { Aabb2 } from '~/util/aabb2'
+
 export class Quadtree<TId, TItem extends QuadtreeItem<TId>> {
   private maxItems: number
-  private aabb: [vec2, vec2] // NW and SE extrema
+  private aabb: Aabb2 // NW and SE extrema
   private root: TNode<TItem>
   private idMap: Map<TId, TNode<TItem>[]>
   private comparator: Comparator<TItem>
 
   constructor(config: {
     maxItems: number
-    aabb: [vec2, vec2]
+    aabb: Aabb2
     comparator: Comparator<TItem>
   }) {
     this.maxItems = config.maxItems
@@ -53,7 +53,7 @@ export class Quadtree<TId, TItem extends QuadtreeItem<TId>> {
     this.idMap.delete(id)
   }
 
-  public query(aabb: [vec2, vec2]): TItem[] {
+  public query(aabb: Aabb2): TItem[] {
     return nodeQuery(this.root, this.aabb, this.comparator, aabb)
   }
 }

--- a/src/util/quadtree/__test__/Quadtree.test.ts
+++ b/src/util/quadtree/__test__/Quadtree.test.ts
@@ -1,20 +1,19 @@
 import { vec2 } from 'gl-matrix'
 
-import { TILE_SIZE } from '~/constants'
+import { Aabb2 } from '~/util/aabb2'
 import { Quadtree } from '~/util/quadtree'
 import {
   minBiasAabbContains,
   minBiasAabbOverlap,
 } from '~/util/quadtree/helpers'
-import { tileBox } from '~/util/tileMath'
 
 type TestItem = {
   id: string
   pos: vec2
 }
 
-const testComparator = (aabb: [vec2, vec2], item: TestItem): boolean => {
-  return minBiasAabbContains(aabb, item.pos)
+const testComparator = (box: Aabb2, item: TestItem): boolean => {
+  return minBiasAabbContains(box, item.pos)
 }
 
 describe('Quadtree', () => {
@@ -32,10 +31,7 @@ describe('Quadtree', () => {
 
     const qt = new Quadtree<string, TestItem>({
       maxItems: 2,
-      aabb: [
-        [0, 1],
-        [4, 5],
-      ],
+      aabb: [0, 1, 4, 5],
       comparator: testComparator,
     })
 
@@ -44,76 +40,49 @@ describe('Quadtree', () => {
     }
 
     // single item, 2 levels deep
-    const q0 = qt.query([
-      [0, 1],
-      [1, 2],
-    ])
+    const q0 = qt.query([0, 1, 1, 2])
     expect(q0.length).toBe(1)
     expect(q0).toContain(items[0])
 
     // single item, 1 level deep
-    const q1 = qt.query([
-      [2.5, 3.5],
-      [3.5, 4.5],
-    ])
+    const q1 = qt.query([2.5, 3.5, 3.5, 4.5])
     expect(q1.length).toBe(1)
     expect(q1).toContain(items[7])
 
     // two items in horizontally adjacent nodes
-    const q2 = qt.query([
-      [0, 1],
-      [2, 2],
-    ])
+    const q2 = qt.query([0, 1, 2, 2])
     expect(q2.length).toBe(2)
     expect(q2).toContain(items[0])
     expect(q2).toContain(items[1])
 
     // two items in vertically adjacent nodes
-    const q3 = qt.query([
-      [0, 1],
-      [1, 3],
-    ])
+    const q3 = qt.query([0, 1, 1, 3])
     expect(q3.length).toBe(2)
     expect(q3).toContain(items[0])
     expect(q3).toContain(items[2])
 
     // two items in the same node
-    const q4 = qt.query([
-      [3.25, 1.25],
-      [3.75, 2.75],
-    ])
+    const q4 = qt.query([3.25, 1.25, 3.75, 2.75])
     expect(q4.length).toBe(2)
     expect(q4).toContain(items[4])
     expect(q4).toContain(items[5])
 
     // two items at different levels
-    const q5 = qt.query([
-      [1.25, 2.25],
-      [3.25, 4.25],
-    ])
+    const q5 = qt.query([1.25, 2.25, 3.25, 4.25])
     expect(q5.length).toBe(2)
     expect(q5).toContain(items[3])
     expect(q5).toContain(items[7])
 
     // no items, two levels deep
-    const q6 = qt.query([
-      [0.75, 1.75],
-      [1.25, 2.25],
-    ])
+    const q6 = qt.query([0.75, 1.75, 1.25, 2.25])
     expect(q6.length).toBe(0)
 
     // no items, multiple levels
-    const q7 = qt.query([
-      [1.75, 2.75],
-      [2.25, 3.25],
-    ])
+    const q7 = qt.query([1.75, 2.75, 2.25, 3.25])
     expect(q7.length).toBe(0)
 
     // no items, outside quadtree area
-    const q8 = qt.query([
-      [5, 6],
-      [6, 7],
-    ])
+    const q8 = qt.query([5, 6, 6, 7])
     expect(q8.length).toBe(0)
   })
 
@@ -123,19 +92,21 @@ describe('Quadtree', () => {
 
     // Set up QT
     const origin = vec2.fromValues(
-      -TILE_SIZE * (squareDimension / 2),
-      -TILE_SIZE * (squareDimension / 2),
+      -(squareDimension / 2),
+      -(squareDimension / 2),
     )
     const qt = new Quadtree<string, { id: string }>({
       maxItems: 4,
-      aabb: [
-        origin,
-        [TILE_SIZE * (squareDimension / 2), TILE_SIZE * (squareDimension / 2)],
-      ],
-      comparator: (aabb: [vec2, vec2], item: { id: string }) => {
+      aabb: [origin[0], origin[1], squareDimension / 2, squareDimension / 2],
+      comparator: (box: Aabb2, item: { id: string }) => {
         const entityPos = entities[item.id]
-        const entityAabb = tileBox(entityPos)
-        return minBiasAabbOverlap(aabb, entityAabb)
+        const entityAabb: Aabb2 = [
+          entityPos[0] - 0.5,
+          entityPos[1] - 0.5,
+          entityPos[0] + 0.5,
+          entityPos[1] + 0.5,
+        ]
+        return minBiasAabbOverlap(box, entityAabb)
       },
     })
 
@@ -145,10 +116,7 @@ describe('Quadtree', () => {
       for (let j = 0; j < squareDimension; j++) {
         entities[id.toString()] = vec2.add(
           vec2.create(),
-          vec2.fromValues(
-            j * TILE_SIZE + TILE_SIZE * 0.5,
-            i * TILE_SIZE + TILE_SIZE * 0.5,
-          ),
+          vec2.fromValues(j + 0.5, i + 0.5),
           origin,
         )
         qt.insert({ id: id.toString() })
@@ -159,24 +127,15 @@ describe('Quadtree', () => {
     // Look up tests
 
     // [0,0] => [3, 1]
-    const res1 = qt.query([
-      origin,
-      vec2.add(
-        vec2.create(),
-        origin,
-        vec2.fromValues(TILE_SIZE * 3, TILE_SIZE),
-      ),
-    ])
+    const res1 = qt.query([origin[0], origin[1], origin[0] + 3, origin[1] + 1])
     expect(res1).toEqual([{ id: '0' }, { id: '1' }, { id: '2' }])
 
     // [1,1] => [4, 4]
     const res2 = qt.query([
-      vec2.add(vec2.create(), origin, vec2.fromValues(TILE_SIZE, TILE_SIZE)),
-      vec2.add(
-        vec2.create(),
-        origin,
-        vec2.fromValues(TILE_SIZE * 4, TILE_SIZE * 4),
-      ),
+      origin[0] + 1,
+      origin[1] + 1,
+      origin[0] + 4,
+      origin[1] + 4,
     ])
     expect(res2).toEqual(
       expect.arrayContaining([

--- a/src/util/quadtree/__test__/helpers.test.ts
+++ b/src/util/quadtree/__test__/helpers.test.ts
@@ -1,6 +1,7 @@
 import { vec2 } from 'gl-matrix'
 
 import * as aabb2 from '../../aabb2'
+import { Aabb2 } from '../../aabb2'
 import {
   ChildList,
   Quadrant,
@@ -18,135 +19,73 @@ type TestItem = {
   pos: vec2
 }
 
-const testComparator = (aabb: [vec2, vec2], item: TestItem): boolean => {
-  return minBiasAabbContains(aabb, item.pos)
+const testComparator = (box: Aabb2, item: TestItem): boolean => {
+  return minBiasAabbContains(box, item.pos)
 }
 
 test('quadrantOfAabb', () => {
-  const aabb: [vec2, vec2] = [vec2.fromValues(0, 0), vec2.fromValues(2, 2)]
+  const a: Aabb2 = [0, 0, 2, 2]
+  expect(quadrantOfAabb(a, Quadrant.NW)).toStrictEqual([0, 0, 1, 1])
+  expect(quadrantOfAabb(a, Quadrant.NE)).toStrictEqual([1, 0, 2, 1])
+  expect(quadrantOfAabb(a, Quadrant.SE)).toStrictEqual([1, 1, 2, 2])
+  expect(quadrantOfAabb(a, Quadrant.SW)).toStrictEqual([0, 1, 1, 2])
 
-  const nw = quadrantOfAabb(aabb, Quadrant.NW)
-  expect(vec2.equals(nw[0], vec2.fromValues(0, 0))).toBe(true)
-  expect(vec2.equals(nw[1], vec2.fromValues(1, 1))).toBe(true)
-
-  const ne = quadrantOfAabb(aabb, Quadrant.NE)
-  expect(vec2.equals(ne[0], vec2.fromValues(1, 0))).toBe(true)
-  expect(vec2.equals(ne[1], vec2.fromValues(2, 1))).toBe(true)
-
-  const se = quadrantOfAabb(aabb, Quadrant.SE)
-  expect(vec2.equals(se[0], vec2.fromValues(1, 1))).toBe(true)
-  expect(vec2.equals(se[1], vec2.fromValues(2, 2))).toBe(true)
-
-  const sw = quadrantOfAabb(aabb, Quadrant.SW)
-  expect(vec2.equals(sw[0], vec2.fromValues(0, 1))).toBe(true)
-  expect(vec2.equals(sw[1], vec2.fromValues(1, 2))).toBe(true)
-})
-
-test('quadrantOfAabb2', () => {
-  const aabb: [vec2, vec2] = [vec2.fromValues(0, 1), vec2.fromValues(2, 3)]
-
-  const nw = quadrantOfAabb(aabb, Quadrant.NW)
-  expect(vec2.equals(nw[0], vec2.fromValues(0, 1))).toBe(true)
-  expect(vec2.equals(nw[1], vec2.fromValues(1, 2))).toBe(true)
-
-  const ne = quadrantOfAabb(aabb, Quadrant.NE)
-  expect(vec2.equals(ne[0], vec2.fromValues(1, 1))).toBe(true)
-  expect(vec2.equals(ne[1], vec2.fromValues(2, 2))).toBe(true)
-
-  const se = quadrantOfAabb(aabb, Quadrant.SE)
-  expect(vec2.equals(se[0], vec2.fromValues(1, 2))).toBe(true)
-  expect(vec2.equals(se[1], vec2.fromValues(2, 3))).toBe(true)
-
-  const sw = quadrantOfAabb(aabb, Quadrant.SW)
-  expect(vec2.equals(sw[0], vec2.fromValues(0, 2))).toBe(true)
-  expect(vec2.equals(sw[1], vec2.fromValues(1, 3))).toBe(true)
+  const b: Aabb2 = [0, 1, 2, 3]
+  expect(quadrantOfAabb(b, Quadrant.NW)).toStrictEqual([0, 1, 1, 2])
+  expect(quadrantOfAabb(b, Quadrant.NE)).toStrictEqual([1, 1, 2, 2])
+  expect(quadrantOfAabb(b, Quadrant.SE)).toStrictEqual([1, 2, 2, 3])
+  expect(quadrantOfAabb(b, Quadrant.SW)).toStrictEqual([0, 2, 1, 3])
 })
 
 test('minBiasAabbContains', () => {
-  const aabb: [vec2, vec2] = [vec2.fromValues(0, 1), vec2.fromValues(1, 2)]
-  expect(minBiasAabbContains(aabb, [0.5, 1.5])).toBe(true) // strict interior
-  expect(minBiasAabbContains(aabb, [10, 11])).toBe(false) // strict exterior
-  expect(minBiasAabbContains(aabb, [0.5, 1])).toBe(true) // north edge
-  expect(minBiasAabbContains(aabb, [0, 1.5])).toBe(true) // west edge
-  expect(minBiasAabbContains(aabb, [0.5, 2])).toBe(false) // south edge
-  expect(minBiasAabbContains(aabb, [1, 1.5])).toBe(false) // east edge
+  const box: Aabb2 = [0, 1, 1, 2]
+  expect(minBiasAabbContains(box, [0.5, 1.5])).toBe(true) // strict interior
+  expect(minBiasAabbContains(box, [10, 11])).toBe(false) // strict exterior
+  expect(minBiasAabbContains(box, [0.5, 1])).toBe(true) // north edge
+  expect(minBiasAabbContains(box, [0, 1.5])).toBe(true) // west edge
+  expect(minBiasAabbContains(box, [0.5, 2])).toBe(false) // south edge
+  expect(minBiasAabbContains(box, [1, 1.5])).toBe(false) // east edge
 })
 
 describe('minBiasAabbOverlap', () => {
   test('fully disjoint', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [2, 3],
-      [3, 4],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [2, 3, 3, 4]
     expect(minBiasAabbOverlap(a, b)).toBe(false)
     expect(minBiasAabbOverlap(b, a)).toBe(false)
   })
 
   test('full enclosure', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [0.25, 1.25],
-      [0.75, 1.75],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [0.25, 1.25, 0.75, 1.75]
     expect(minBiasAabbOverlap(a, b)).toBe(true)
     expect(minBiasAabbOverlap(b, a)).toBe(true)
   })
 
   test('partial overlap', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [0.5, 1.5],
-      [1.5, 2.5],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [0.5, 1.5, 1.5, 2.5]
     expect(minBiasAabbOverlap(a, b)).toBe(true)
     expect(minBiasAabbOverlap(b, a)).toBe(true)
   })
 
   test('shared north edge', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [0.5, 1],
-      [1, 1.5],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [0.5, 1, 1, 1.5]
     expect(minBiasAabbOverlap(a, b)).toBe(true)
     expect(minBiasAabbOverlap(b, a)).toBe(true)
   })
 
   test('shared west edge', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [0, 1.5],
-      [0.5, 2],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [0, 1.5, 0.5, 2]
     expect(minBiasAabbOverlap(a, b)).toBe(true)
     expect(minBiasAabbOverlap(b, a)).toBe(true)
   })
 
   test('vertically adjacent, no overlap', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [0, 2],
-      [1, 3],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [0, 2, 1, 3]
 
     expect(aabb2.overlap(a, b)).toBe(true)
     expect(aabb2.overlap(b, a)).toBe(true)
@@ -155,14 +94,8 @@ describe('minBiasAabbOverlap', () => {
   })
 
   test('horizontally adjacent, no overlap', () => {
-    const a: [vec2, vec2] = [
-      [0, 1],
-      [1, 2],
-    ]
-    const b: [vec2, vec2] = [
-      [1, 1],
-      [2, 2],
-    ]
+    const a: Aabb2 = [0, 1, 1, 2]
+    const b: Aabb2 = [1, 1, 2, 2]
 
     expect(aabb2.overlap(a, b)).toBe(true)
     expect(aabb2.overlap(b, a)).toBe(true)
@@ -175,20 +108,10 @@ describe('nodeInsert', () => {
   test('insert attempt into non-enclosing node', () => {
     const node = emptyNode<TestItem>()
     const idMap: Map<string, TNode<TestItem>[]> = new Map()
-    nodeInsert(
-      node,
-      idMap,
-      [
-        [0, 1],
-        [1, 2],
-      ],
-      1,
-      testComparator,
-      {
-        id: 'a',
-        pos: [-1, 0],
-      },
-    )
+    nodeInsert(node, idMap, [0, 1, 1, 2], 1, testComparator, {
+      id: 'a',
+      pos: [-1, 0],
+    })
 
     expect(node.items!.length).toBe(0)
 
@@ -199,17 +122,7 @@ describe('nodeInsert', () => {
     const node = emptyNode<TestItem>()
     const idMap: Map<string, TNode<TestItem>[]> = new Map()
     const item = { id: 'a', pos: vec2.fromValues(0, 1) }
-    nodeInsert(
-      node,
-      idMap,
-      [
-        [0, 1],
-        [1, 2],
-      ],
-      1,
-      testComparator,
-      item,
-    )
+    nodeInsert(node, idMap, [0, 1, 1, 2], 1, testComparator, item)
 
     expect(node.items!.length).toBe(1)
     expect(node.items![0]).toBe(item)
@@ -236,17 +149,7 @@ describe('nodeInsert', () => {
     ]
 
     for (const i of items) {
-      nodeInsert(
-        node,
-        idMap,
-        [
-          [0, 1],
-          [2, 3],
-        ],
-        1,
-        testComparator,
-        i,
-      )
+      nodeInsert(node, idMap, [0, 1, 2, 3], 1, testComparator, i)
     }
 
     expect(node.items).toBeUndefined()
@@ -277,17 +180,7 @@ describe('nodeInsert', () => {
     const idMap: Map<string, TNode<TestItem>[]> = new Map()
 
     for (const i of items) {
-      nodeInsert(
-        node,
-        idMap,
-        [
-          [0, 1],
-          [2, 3],
-        ],
-        3,
-        testComparator,
-        i,
-      )
+      nodeInsert(node, idMap, [0, 1, 2, 3], 3, testComparator, i)
     }
 
     expect(node.items).toBeUndefined()
@@ -319,52 +212,30 @@ describe('nodeQuery', () => {
 
   test('no overlap with node AABB', () => {
     expect(
-      nodeQuery(
-        { items },
-        [
-          [-1, 0],
-          [1, 2],
-        ],
-        minBiasAabbContains,
-        [
-          [2, 3],
-          [3, 4],
-        ],
-      ).length,
+      nodeQuery({ items }, [-1, 0, 1, 2], minBiasAabbContains, [2, 3, 3, 4])
+        .length,
     ).toBe(0)
   })
 
   test('no overlap with items', () => {
     expect(
-      nodeQuery(
-        { items },
-        [
-          [-1, 0],
-          [1, 2],
-        ],
-        minBiasAabbContains,
-        [
-          [-0.25, 0.75],
-          [0.25, 1.25],
-        ],
-      ).length,
+      nodeQuery({ items }, [-1, 0, 1, 2], minBiasAabbContains, [
+        -0.25,
+        0.75,
+        0.25,
+        1.25,
+      ]).length,
     ).toBe(0)
   })
 
   test('no overlap with some items', () => {
     const node = { items }
-    const results = nodeQuery(
-      node,
-      [
-        [-1, 0],
-        [1, 2],
-      ],
-      minBiasAabbContains,
-      [
-        [-0.75, 0.25],
-        [0, 2],
-      ],
-    )
+    const results = nodeQuery(node, [-1, 0, 1, 2], minBiasAabbContains, [
+      -0.75,
+      0.25,
+      0,
+      2,
+    ])
     expect(results.length).toBe(2)
     expect(results[0]).toBe(items[0])
     expect(results[1]).toBe(items[3])

--- a/src/util/tileMath.ts
+++ b/src/util/tileMath.ts
@@ -2,11 +2,14 @@ import { vec2 } from 'gl-matrix'
 
 import { TILE_SIZE } from '~/constants'
 import { Immutable } from '~/types/immutable'
+import { Aabb2 } from '~/util/aabb2'
 
-export const tileBox = (pos: Immutable<vec2>): [vec2, vec2] => {
+export const tileBox = (pos: Immutable<vec2>): Aabb2 => {
   return [
-    vec2.fromValues(pos[0] - TILE_SIZE / 2, pos[1] - TILE_SIZE / 2),
-    vec2.fromValues(pos[0] + TILE_SIZE / 2, pos[1] + TILE_SIZE / 2),
+    pos[0] - TILE_SIZE / 2,
+    pos[1] - TILE_SIZE / 2,
+    pos[0] + TILE_SIZE / 2,
+    pos[1] + TILE_SIZE / 2,
   ]
 }
 


### PR DESCRIPTION
This change turns our standard AABB structure from `[vec2, vec2]` into `[number, number, number, number]`.

Pro:
- I get about 0.2-0.3ms per-frame speed improvement (about 7-8%) on the big map when close to turrets.
- I think a 4-tuple is, by itself, a simpler thing to work with than `[vec2, vec2]`.

Con:
- This is a neutral or slight negative in terms of code. The data structure itself is actually simpler, but it may be easier to mix up the elements of a 4-tuple, and there are no convenient math helpers like `vec2.scale` or `vec2.add`. (Not actually sure those are real problems?)
- This introduces a pretty glaring inconsistency between the old way of handling vectors and a new, less DRY way.